### PR TITLE
Expanded soft_quota.py to include multiple quotas and provide for automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+credentials.txt
+quotas.txt

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 soft_quota.py will run a check against a Qumulo cluster running Qumulo Core 1.2.9 or later. Requires python 2.7. 
 The script will generate a csv file containing the quota name and the current usage and will email if the quota is exceeded.
 
-Credentials for the Qumulo cluster must be provided in a credentials.txt file. There is a sample file provided. Format is space delimited, 
-in the following order: 
-cluster_fqdn name password port_number
+Credentials are defined with environment variables, as follows: 
+$QUMULO_CLUSTER  #Cluster FQDN
+$QUMULO_USER     #Username with rights to use API
+$QUMULO_PWD      #Password for that user
 
 Quotas are defined in the quotas.txt file and are space delimited. A sample file is provided. Format is as follows: 
 quota_name /storage/system/path /nfs/mount/path quota_size_in_TB

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # soft_quota
+soft_quota.py will run a check against a Qumulo cluster running Qumulo Core 1.2.9 or later. Requires python 2.7. 
+The script will generate a csv file containing the quota name and the current usage and will email if the quota is exceeded.
+
+Credentials for the Qumulo cluster must be provided in a credentials.txt file. There is a sample file provided. Format is space delimited, 
+in the following order: 
+cluster_fqdn name password port_number
+
+Quotas are defined in the quotas.txt file and are space delimited. A sample file is provided. Format is as follows: 
+quota_name /storage/system/path /nfs/mount/path quota_size_in_TB

--- a/credentials_sample.txt
+++ b/credentials_sample.txt
@@ -1,1 +1,0 @@
-cluster1.qumulo.com admin admin 8000

--- a/credentials_sample.txt
+++ b/credentials_sample.txt
@@ -1,0 +1,1 @@
+cluster1.qumulo.com admin admin 8000

--- a/quotas_sample.txt
+++ b/quotas_sample.txt
@@ -1,0 +1,6 @@
+developers /filestore/departments/developers /mnt/departments/developers 30.0
+executives /filestore/departments/exexutives /mnt/departments/executives 40.0
+flylight /filestore/departments/flylight /mnt/departments/flylight 30.0
+it /filestore/departments/it /mnt/departments/it 120.0
+engineering /filestore/departments/engineering /mnt/departments/engineering 260.0
+hr /filestore/departments/hr /mnt/departments/hr 20.0

--- a/soft_quota.py
+++ b/soft_quota.py
@@ -44,14 +44,14 @@ storagename = '[QUMULO CLUSTER]' # for email subject
 
 # Import credentials
 # credentials.txt formatted as single line composed of <host fqdn> <username> <password> <portnumber (default 8000)>
-with open("credentials.txt") as file:
+with open(os.path.join(sys.path[0], "credentials.txt"),"r") as file:
     line = file.readline()
     host, user, password, port = line.split() 
 
 # Import quota dictionary from quotas.txt file
 # quotas.txt formatted as one line per quota formatted as <short name> <path on Qumulo storage> <nfs mount path> <quota size in TB>
 quota_dict = {}
-with open("quotas.txt") as file:
+with open(os.path.join(sys.path[0], "quotas.txt"),"r") as file:
     for line in file:
         quotaname, storage_path, nfs_path, size = line.split()
         quota_dict[quotaname] = (storage_path, nfs_path, float(size))

--- a/soft_quota.py
+++ b/soft_quota.py
@@ -13,7 +13,6 @@
 
 
 # Import python libraries
-import argparse
 import os
 import sys
 import smtplib
@@ -26,9 +25,37 @@ import qumulo.lib.opts
 import qumulo.lib.request
 import qumulo.rest
 
+# Size Definitions
 KILOBYTE = 1024
 MEGABYTE = 1024 * KILOBYTE
 GIGABYTE = 1024 * MEGABYTE
+TERABYTE = 1024 * GIGABYTE
+
+###############CHANGE THESE SETTINGS AND CREATE THESE FILES FOR YOUR ENVIRONMENT #####################################
+# Email settings
+smtp_server = '10.42.5.23'
+sender = 'nrs@janelia.hhmi.org'
+recipients = ['scicompsys@janelia.hhmi.org', 'saffordt@janelia.hhmi.org']
+
+# Location to write log file and header line for log file
+logfile = '/groups/scicomp/reports/nrs_usage/lab_usage.log'
+header = 'Lab,SpaceUsed'
+storagename = '[NRS]' # for email subject
+
+# Import credentials
+# credentials.txt formatted as single line composed of <host fqdn> <username> <password> <portnumber (default 8000)>
+with open("credentials.txt") as file:
+    line = file.readline()
+    host, user, password, port = line.split() 
+
+# Import quota dictionary from quotas.txt file
+# quotas.txt formatted as one line per quota formatted as <short name> <path on Qumulo storage> <nfs mount path> <quota size in TB>
+quota_dict = {}
+with open("quotas.txt") as file:
+    for line in file:
+        quotaname, storage_path, nfs_path, size = line.split()
+        quota_dict[quotaname] = (storage_path, nfs_path, float(size))
+######################################################################################################################
 
 def login(host, user, passwd, port):
     '''Obtain credentials from the REST server'''
@@ -41,7 +68,7 @@ def login(host, user, passwd, port):
 
         # Provide username and password to retreive authentication tokens
         # used by the credentials object
-        login_results, _ = qumulo.rest.auth.login(\
+        login_results, _ = qumulo.rest.auth.login(
                 conninfo, None, user, passwd)
 
         # Create the credentials object which will be used for
@@ -54,66 +81,58 @@ def login(host, user, passwd, port):
 
     return (conninfo, creds)
 
-def send_mail(smtp_server, sender, recipient, subject, body):
-    ''' send_mail '''
+def send_mail(smtp_server, sender, recipients, subject, body):
     mmsg = MIMEText(body, 'html')
     mmsg['Subject'] = subject
     mmsg['From'] = sender
-    mmsg['To'] = recipient
+    mmsg['To'] = ", ".join(recipients)
 
     session = smtplib.SMTP(smtp_server)
-    session.sendmail(sender, [recipient], mmsg.as_string())
+    session.sendmail(sender, recipients, mmsg.as_string())
     session.quit()
 
-def monitor_path(path, quota, conninfo, creds, smtp_server, sender, recipient):
-    ''' monitor_path '''
-    node = qumulo.rest.fs.read_dir_aggregates(conninfo, creds, path)
-    quota = int(quota) * GIGABYTE
-    subject = "Quota exceeded"
+def build_mail(nfspath, quota, current_usage, smtp_server, sender, recipients):
+    sane_current_usage = float(current_usage) / float(TERABYTE)
+    subject = storagename + "Quota exceeded"
     body = ""
+    body += "The usage on {} has exceeded the quota.<br>".format(nfspath)
+    body += "Current usage: %0.2f TB<br>" %sane_current_usage 
+    body += "Quota: %0.2f TB<br>" %quota
+    body += "<br>"
+    send_mail(smtp_server, sender, recipients, subject, body)
+        
+# Build email and check against quota for notification, return current usage for tracking
+def monitor_path(path, conninfo, creds):
+    try:
+        node = qumulo.rest.fs.read_dir_aggregates(conninfo, creds, path)
+    except Exception, excpt:
+        print 'Error retrieving path: %s' % excpt
+    else:
+        current_usage = int(node[0]['total_capacity'])
+        return current_usage
 
-    current_usage = int(node[0]['total_capacity'])
-    if current_usage > quota:
-        excess_usage = abs(quota - current_usage)
-        body += "Your usage on " + path + " exceeded your quota. "
-        body += "Current usage is " + str(current_usage) + \
-               ", while the quota specified is " + str(quota)
-        body += ". You exceeded the quota by: " + str("{:.2f}".format(excess_usage) + " bytes.")
-        body += "<br>"
-
-    for n in node[0]['files']:
-        if n['type'] == 'FS_FILE_TYPE_DIRECTORY':
-            current_usage = int(n['capacity_usage'])
-            print n['name']
-            if current_usage >= quota:
-                excess_usage = abs(quota - current_usage)
-                body += "Your usage on " + path + "/" + n['name'].encode('utf-8') + " exceeded your quota. "
-                body += "Current usage is " + str(current_usage) + \
-                       ", while the quota specified is " + str(quota)
-                body += ". You exceeded the quota by: " + str("{:.2f}".format(excess_usage) + " bytes.")
-                body += "<br>"
-
-    if body:
-        send_mail(smtp_server, sender, recipient,  subject, body)
-
+def build_csv(quotaname, current_usage, logfile):
+    with open(logfile, "a") as file:
+        file.write(quotaname + ',' + str(current_usage) + '\n')
+        
 ### Main subroutine
 def main(argv):
+    # Get credentials
+    (conninfo, creds) = login(host, user, password, port)
+    
+    # Overwrite log file
+    with open(logfile, "w") as file:
+        file.write(header + '\n')
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--host', dest='host', required=True)
-    parser.add_argument('--user', dest='user', required=True)
-    parser.add_argument('--password', dest='password', required=True)
-    parser.add_argument('--port', dest='port', default=8000, type=int)
-    parser.add_argument('--path', dest='path', default='/')
-    parser.add_argument('--quota', dest='quota', required=True, type=float)
-    parser.add_argument('--smtp', dest='smtp', default='mail.corp.qumulo.com')
-    parser.add_argument('--sender', dest='sender', default='qdf@qumulo.com')
-    parser.add_argument('--recipient', dest='recipient', default='karim@qumulo.com')
-
-    opts = parser.parse_args(argv)
-    (conninfo, creds) = login(opts.host, opts.user, opts.password, opts.port)
-    monitor_path(opts.path, opts.quota, conninfo, creds, opts.smtp,
-                 opts.sender, opts.recipient)
+    # Get quotas and generate CSV
+    for quotaname in quota_dict.keys():
+        path, nfspath, quota = quota_dict[quotaname]
+        current_usage = monitor_path(path, conninfo, creds)
+        if current_usage is not None:
+            quotaraw = int(quota) * TERABYTE
+            if current_usage > quotaraw:
+                build_mail(nfspath, quota, current_usage, smtp_server, sender, recipients)
+            build_csv(quotaname, current_usage, logfile)    
 
 # Main
 if __name__ == '__main__':

--- a/soft_quota.py
+++ b/soft_quota.py
@@ -43,10 +43,10 @@ header = 'Group,SpaceUsed'
 storagename = '[QUMULO CLUSTER]' # for email subject
 
 # Import credentials
-# credentials.txt formatted as single line composed of <host fqdn> <username> <password> <portnumber (default 8000)>
-with open(os.path.join(sys.path[0], "credentials.txt"),"r") as file:
-    line = file.readline()
-    host, user, password, port = line.split() 
+host = os.environ.get('SQ_CLUSTER')
+port = 8000
+user = os.environ.get('SQ_USER') or 'admin'
+password = os.environ.get('SQ_PWD') or 'admin'
 
 # Import quota dictionary from quotas.txt file
 # quotas.txt formatted as one line per quota formatted as <short name> <path on Qumulo storage> <nfs mount path> <quota size in TB>

--- a/soft_quota.py
+++ b/soft_quota.py
@@ -33,14 +33,14 @@ TERABYTE = 1024 * GIGABYTE
 
 ###############CHANGE THESE SETTINGS AND CREATE THESE FILES FOR YOUR ENVIRONMENT #####################################
 # Email settings
-smtp_server = '10.42.5.23'
-sender = 'nrs@janelia.hhmi.org'
-recipients = ['scicompsys@janelia.hhmi.org', 'saffordt@janelia.hhmi.org']
+smtp_server = 'smtp.example.com'
+sender = 'qumulo_cluster@example.com'
+recipients = ['recipient1@example.com', 'recipient2@example.com']
 
 # Location to write log file and header line for log file
-logfile = '/groups/scicomp/reports/nrs_usage/lab_usage.log'
-header = 'Lab,SpaceUsed'
-storagename = '[NRS]' # for email subject
+logfile = './group_usage.log'
+header = 'Group,SpaceUsed'
+storagename = '[QUMULO CLUSTER]' # for email subject
 
 # Import credentials
 # credentials.txt formatted as single line composed of <host fqdn> <username> <password> <portnumber (default 8000)>

--- a/soft_quota.py
+++ b/soft_quota.py
@@ -43,10 +43,10 @@ header = 'Group,SpaceUsed'
 storagename = '[QUMULO CLUSTER]' # for email subject
 
 # Import credentials
-host = os.environ.get('SQ_CLUSTER')
+host = os.environ.get('QUMULO_CLUSTER')
 port = 8000
-user = os.environ.get('SQ_USER') or 'admin'
-password = os.environ.get('SQ_PWD') or 'admin'
+user = os.environ.get('QUMULO_USER')
+password = os.environ.get('QUMULO_PWD') or 'admin'
 
 # Import quota dictionary from quotas.txt file
 # quotas.txt formatted as one line per quota formatted as <short name> <path on Qumulo storage> <nfs mount path> <quota size in TB>


### PR DESCRIPTION
I've refactored the soft_quota.py code to read a list of quotas from a file and then check all of those quotas, emailing when a quota is exceeded and also creating a csv of quotaname,current_usage. I also added a TERABYTE field and made the default quota definition be in TB. I also changed from KB/MB/GB to KiB/MiB/GiB/TiB. Separated out credentials into a separate file. 
